### PR TITLE
Add support for zk namespaces

### DIFF
--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -3,6 +3,7 @@ package consumergroup
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -105,6 +106,14 @@ func JoinConsumerGroup(name string, topics []string, zookeeper []string, config 
 	// Validate configuration
 	if err = config.Validate(); err != nil {
 		return
+	}
+
+	// check for namespaces
+	for index, zkServer := range zookeeper {
+		if strings.Contains(zkServer, "/") {
+			_, config.Zookeeper.Chroot = kazoo.ParseConnectionString(zkServer)
+			zookeeper[index] = zkServer[0:strings.Index(zkServer, "/")]
+		}
 	}
 
 	var kz *kazoo.Kazoo

--- a/consumergroup/consumer_group.go
+++ b/consumergroup/consumer_group.go
@@ -111,7 +111,9 @@ func JoinConsumerGroup(name string, topics []string, zookeeper []string, config 
 	// check for namespaces
 	for index, zkServer := range zookeeper {
 		if strings.Contains(zkServer, "/") {
+			// set the root of the zookeeper hierarchy to what is specified in the connect string
 			_, config.Zookeeper.Chroot = kazoo.ParseConnectionString(zkServer)
+			// trim the uri of the server to exclude the root
 			zookeeper[index] = zkServer[0:strings.Index(zkServer, "/")]
 		}
 	}


### PR DESCRIPTION
To support several kafka clusters it is possible to configure zookeeper hierarchy for kafka to ues namespaces (i.e. brokers live under /confabc instead of /). This change handles this use case in addition to the default.
